### PR TITLE
Added tag color support for cards

### DIFF
--- a/components/Root.svelte
+++ b/components/Root.svelte
@@ -85,6 +85,8 @@
 			renderFile={(el) => renderFile(file, el)}
 			openFile={() => openFile(file)}
 			trashFile={() => trashFile(file)}
+			tags={settings.tags}
+			textColor={settings.textColor}
 			on:loaded={() => notesGrid.layout()}
 		/>
 	{/each}

--- a/settings.ts
+++ b/settings.ts
@@ -1,12 +1,21 @@
 import CardsViewPlugin from "./main";
 import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 
+export interface TagSetting {
+    name: string;
+    color: string;
+}
+
 export interface CardsViewSettings {
 	minCardWidth: number;
+	textColor: string;
+	tags: TagSetting[];
 }
 
 export const DEFAULT_SETTINGS: CardsViewSettings = {
 	minCardWidth: 200,
+	textColor: '#000',
+	tags: [],
 };
 
 export class CardsViewSettingsTab extends PluginSettingTab {
@@ -21,7 +30,7 @@ export class CardsViewSettingsTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		new Setting(containerEl)
+			new Setting(containerEl)
 			.setName("Minimum card width")
 			.setDesc("Cards will not be smaller than this width (in pixels)")
 			.addText((text) =>
@@ -38,5 +47,58 @@ export class CardsViewSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}),
 			);
+
+
+			containerEl.createEl('div', { text: 'Card colors', cls:'setting-item setting-item-heading' });
+		
+			new Setting(containerEl)
+			.setName("Card text color")
+			.setDesc("Define default text color for colored cards")
+			.addColorPicker((text) =>
+				text
+					.setValue(this.plugin.settings.textColor)
+					.onChange(async (value) => {
+						this.plugin.settings.textColor = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+			containerEl.createEl('div', { text: 'Tag colors', cls:'setting-item-name' });
+			containerEl.createEl('div', { text: 'Define a card background-color for your tags', cls:'setting-item-description' });
+
+			this.plugin.settings.tags.forEach((tag, index) => {
+				const setting = new Setting(containerEl)
+					.addText(text => text
+						.setPlaceholder('Tag Name')
+						.setValue(tag.name)
+						.onChange(async (value) => {
+							this.plugin.settings.tags[index].name = value;
+							await this.plugin.saveSettings();
+						}))
+					.addColorPicker(text => text
+						.setValue(tag.color)
+						.onChange(async (value) => {
+							this.plugin.settings.tags[index].color = value;
+							await this.plugin.saveSettings();
+						}))
+					.addButton(button => button
+						.setButtonText('Delete')
+						.setCta()
+						.onClick(async () => {
+							this.plugin.settings.tags.splice(index, 1);
+							await this.plugin.saveSettings();
+							this.display();
+						}));
+			});
+	
+			new Setting(containerEl)
+				.addButton(button => button
+					.setButtonText('Add Tag')
+					.setCta()
+					.onClick(async () => {
+						this.plugin.settings.tags.push({ name: '', color: '' });
+						await this.plugin.saveSettings();
+						this.display();
+					}));
 	}
 }


### PR DESCRIPTION
This pull request introduces tag color support for cards, similar to the functionality in Google Keep. Users can now configure colors for each tag in the plugin settings, enhancing the visual organization of their notes and tasks.

![cards](https://github.com/jillro/obsidian-cards-view-plugin/assets/3475978/9e875d93-d4dd-43f0-8639-fe3b1dcff77a)
![cardsettings](https://github.com/jillro/obsidian-cards-view-plugin/assets/3475978/adafed0d-58fb-46ff-a3f7-691ec39a0af3)

Feel free to reorganize the code if you find any areas that could be improved.

Thanks for the great plugin!