### PR TITLE
feat: add "Maximum columns" setting

### DIFF
--- a/src/components/Root.svelte
+++ b/src/components/Root.svelte
@@ -14,9 +14,17 @@
     settings,
   } from "./store";
 
+  const GUTTER = 20;
+
   let notesGrid: MiniMasonry;
   let cardsContainer: HTMLElement;
   let cardWidth: number = $state(0);
+
+  const maxContentWidth = $derived(
+    $settings.maxColumns > 0
+      ? `${$settings.maxColumns * ($settings.minCardWidth + GUTTER) - GUTTER}px`
+      : "none",
+  );
 
   async function updateCardWidth() {
     // Get the first card's width, or use the baseWidth setting as fallback
@@ -72,9 +80,9 @@
     notesGrid = new MiniMasonry({
       container: cardsContainer,
       baseWidth: $settings.minCardWidth,
-      gutter: 20,
+      gutter: GUTTER,
       surroundingGutter: false,
-      ultimateGutter: 20,
+      ultimateGutter: GUTTER,
       wedge: true,
     });
     notesGrid.layout();
@@ -83,6 +91,18 @@
     return () => {
       notesGrid.destroy();
     };
+  });
+
+  $effect(() => {
+    // touch settings so the effect re-runs when they change
+    const { minCardWidth } = $settings;
+    void maxContentWidth; // re-run when the cap width changes
+    if (!notesGrid) return;
+    // `conf` is not in MiniMasonry's type defs but holds the live config it
+    // reads on each layout(); keep baseWidth in sync with the setting.
+    (notesGrid as unknown as { conf: { baseWidth: number } }).conf.baseWidth =
+      minCardWidth;
+    tick().then(() => notesGrid.layout());
   });
 
   let lastLayout: Date = new Date();
@@ -198,6 +218,7 @@
   class="cards-container"
   bind:this={cardsContainer}
   style:--card-width="{cardWidth}px"
+  style:max-width={maxContentWidth}
 >
   {#each $displayedFiles as file (file.path + file.stat.mtime)}
     <Card {file} {updateLayoutNextTick} />
@@ -312,6 +333,7 @@
   .cards-container {
     position: relative;
     container-type: inline-size;
+    margin-inline: auto;
   }
 
   .cards-container :global(*) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export enum TitleDisplayMode {
 export interface CardsViewSettings {
   baseQuery: string;
   minCardWidth: number;
+  maxColumns: number;
   launchOnStart: boolean;
   showDeleteButton: boolean;
   displayTitle: TitleDisplayMode;
@@ -21,6 +22,7 @@ export interface CardsViewSettings {
 export const DEFAULT_SETTINGS: CardsViewSettings = {
   baseQuery: "",
   minCardWidth: 200,
+  maxColumns: 0,
   launchOnStart: false,
   showDeleteButton: true,
   displayTitle: TitleDisplayMode.Both,
@@ -72,6 +74,26 @@ export class CardsViewSettingsTab extends PluginSettingTab {
             settings.update((s) => ({
               ...s,
               minCardWidth: parseInt(value),
+            }));
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Maximum columns")
+      .setDesc("Limit the number of columns. Set to 0 for no limit.")
+      .addText((text) =>
+        text
+          .setPlaceholder("0")
+          .setValue(this.plugin.settings.maxColumns.toString())
+          .onChange((value) => {
+            if (isNaN(parseInt(value))) {
+              new Notice("Invalid number");
+              return;
+            }
+
+            settings.update((s) => ({
+              ...s,
+              maxColumns: parseInt(value),
             }));
           }),
       );


### PR DESCRIPTION
Cap how many columns the card grid shows on wide panes. When the cap is reached, cards keep their natural size and the block is centered (no stretching). Default `0` = no limit, so existing behavior is unchanged.